### PR TITLE
tweaks first run docker

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@8575951200e472d5f2d95c625da0c7bec8217c42 # v1.161.0
         with:
-          ruby-version: '3.1' # Not needed with a .ruby-version file
+          ruby-version: '3.3.6' # Not needed with a .ruby-version file
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           cache-version: 0 # Increment this number if you need to re-download cached gems
       - name: Setup Pages
@@ -44,7 +44,7 @@ jobs:
         uses: actions/configure-pages@v5
       - name: Build with Jekyll
         # Outputs to the './_site' directory by default
-        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }} --config _config.yml,_config_github_pages.yml"
         env:
           JEKYLL_ENV: production
       - name: Upload artifact

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 
 .jekyll-cache
 _site
-Gemfile.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM ruby:3.3.6
+
+# throw errors if Gemfile has been modified since Gemfile.lock
+RUN bundle config --global frozen 1
+
+WORKDIR /usr/src/app
+
+COPY Gemfile Gemfile.lock ./
+RUN bundle install
+
+COPY . .
+
+CMD ["bundle", "exec", "jekyll", "serve"]
+

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source "https://rubygems.org"
 
+gem "base64"
+gem "csv"
 gem "jekyll", "~> 4.3.3"
 gem "jekyll-environment-variables"
 gem 'wdm', '>= 0.1.0' if Gem.win_platform?

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,110 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
+    bigdecimal (3.1.8)
+    colorator (1.1.0)
+    concurrent-ruby (1.3.4)
+    em-websocket (0.5.3)
+      eventmachine (>= 0.12.9)
+      http_parser.rb (~> 0)
+    eventmachine (1.2.7)
+    ffi (1.17.0)
+    ffi (1.17.0-arm64-darwin)
+    ffi (1.17.0-x86_64-darwin)
+    ffi (1.17.0-x86_64-linux-gnu)
+    forwardable-extended (2.6.0)
+    google-protobuf (4.28.3)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.28.3-arm64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.28.3-x86_64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.28.3-x86_64-linux)
+      bigdecimal
+      rake (>= 13)
+    http_parser.rb (0.8.0)
+    i18n (1.14.6)
+      concurrent-ruby (~> 1.0)
+    jekyll (4.3.4)
+      addressable (~> 2.4)
+      colorator (~> 1.0)
+      em-websocket (~> 0.5)
+      i18n (~> 1.0)
+      jekyll-sass-converter (>= 2.0, < 4.0)
+      jekyll-watch (~> 2.0)
+      kramdown (~> 2.3, >= 2.3.1)
+      kramdown-parser-gfm (~> 1.0)
+      liquid (~> 4.0)
+      mercenary (>= 0.3.6, < 0.5)
+      pathutil (~> 0.9)
+      rouge (>= 3.0, < 5.0)
+      safe_yaml (~> 1.0)
+      terminal-table (>= 1.8, < 4.0)
+      webrick (~> 1.7)
+    jekyll-environment-variables (1.0.1)
+      jekyll (>= 3.0, < 5.x)
+    jekyll-sass-converter (3.0.0)
+      sass-embedded (~> 1.54)
+    jekyll-watch (2.2.1)
+      listen (~> 3.0)
+    kramdown (2.4.0)
+      rexml
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
+    liquid (4.0.4)
+    listen (3.9.0)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    mercenary (0.4.0)
+    pathutil (0.16.2)
+      forwardable-extended (~> 2.6)
+    public_suffix (6.0.1)
+    rake (13.2.1)
+    rb-fsevent (0.11.2)
+    rb-inotify (0.11.1)
+      ffi (~> 1.0)
+    rexml (3.3.9)
+    rouge (4.4.0)
+    safe_yaml (1.0.5)
+    sass-embedded (1.80.6)
+      google-protobuf (~> 4.28)
+      rake (>= 13)
+    sass-embedded (1.80.6-aarch64-mingw-ucrt)
+      google-protobuf (~> 4.28)
+    sass-embedded (1.80.6-arm64-darwin)
+      google-protobuf (~> 4.28)
+    sass-embedded (1.80.6-x86-cygwin)
+      google-protobuf (~> 4.28)
+    sass-embedded (1.80.6-x86-mingw-ucrt)
+      google-protobuf (~> 4.28)
+    sass-embedded (1.80.6-x86_64-cygwin)
+      google-protobuf (~> 4.28)
+    sass-embedded (1.80.6-x86_64-darwin)
+      google-protobuf (~> 4.28)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
+    unicode-display_width (2.6.0)
+    webrick (1.9.0)
+
+PLATFORMS
+  aarch64-mingw-ucrt
+  arm64-darwin
+  ruby
+  x86-cygwin
+  x86-mingw-ucrt
+  x86_64-cygwin
+  x86_64-darwin
+  x86_64-linux
+
+DEPENDENCIES
+  jekyll (~> 4.3.3)
+  jekyll-environment-variables
+  webrick
+
+BUNDLED WITH
+   2.5.18

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,22 +3,37 @@ GEM
   specs:
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
+    base64 (0.2.0)
     bigdecimal (3.1.8)
     colorator (1.1.0)
     concurrent-ruby (1.3.4)
+    csv (3.3.0)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
     ffi (1.17.0)
+    ffi (1.17.0-aarch64-linux-gnu)
+    ffi (1.17.0-aarch64-linux-musl)
+    ffi (1.17.0-arm-linux-gnu)
+    ffi (1.17.0-arm-linux-musl)
     ffi (1.17.0-arm64-darwin)
+    ffi (1.17.0-x86-linux-gnu)
+    ffi (1.17.0-x86-linux-musl)
     ffi (1.17.0-x86_64-darwin)
     ffi (1.17.0-x86_64-linux-gnu)
+    ffi (1.17.0-x86_64-linux-musl)
     forwardable-extended (2.6.0)
     google-protobuf (4.28.3)
       bigdecimal
       rake (>= 13)
+    google-protobuf (4.28.3-aarch64-linux)
+      bigdecimal
+      rake (>= 13)
     google-protobuf (4.28.3-arm64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.28.3-x86-linux)
       bigdecimal
       rake (>= 13)
     google-protobuf (4.28.3-x86_64-darwin)
@@ -74,11 +89,35 @@ GEM
     sass-embedded (1.80.6)
       google-protobuf (~> 4.28)
       rake (>= 13)
+    sass-embedded (1.80.6-aarch64-linux-android)
+      google-protobuf (~> 4.28)
+    sass-embedded (1.80.6-aarch64-linux-gnu)
+      google-protobuf (~> 4.28)
+    sass-embedded (1.80.6-aarch64-linux-musl)
+      google-protobuf (~> 4.28)
     sass-embedded (1.80.6-aarch64-mingw-ucrt)
+      google-protobuf (~> 4.28)
+    sass-embedded (1.80.6-arm-linux-androideabi)
+      google-protobuf (~> 4.28)
+    sass-embedded (1.80.6-arm-linux-gnueabihf)
+      google-protobuf (~> 4.28)
+    sass-embedded (1.80.6-arm-linux-musleabihf)
       google-protobuf (~> 4.28)
     sass-embedded (1.80.6-arm64-darwin)
       google-protobuf (~> 4.28)
+    sass-embedded (1.80.6-riscv64-linux-android)
+      google-protobuf (~> 4.28)
+    sass-embedded (1.80.6-riscv64-linux-gnu)
+      google-protobuf (~> 4.28)
+    sass-embedded (1.80.6-riscv64-linux-musl)
+      google-protobuf (~> 4.28)
     sass-embedded (1.80.6-x86-cygwin)
+      google-protobuf (~> 4.28)
+    sass-embedded (1.80.6-x86-linux-android)
+      google-protobuf (~> 4.28)
+    sass-embedded (1.80.6-x86-linux-gnu)
+      google-protobuf (~> 4.28)
+    sass-embedded (1.80.6-x86-linux-musl)
       google-protobuf (~> 4.28)
     sass-embedded (1.80.6-x86-mingw-ucrt)
       google-protobuf (~> 4.28)
@@ -86,25 +125,51 @@ GEM
       google-protobuf (~> 4.28)
     sass-embedded (1.80.6-x86_64-darwin)
       google-protobuf (~> 4.28)
+    sass-embedded (1.80.6-x86_64-linux-android)
+      google-protobuf (~> 4.28)
+    sass-embedded (1.80.6-x86_64-linux-gnu)
+      google-protobuf (~> 4.28)
+    sass-embedded (1.80.6-x86_64-linux-musl)
+      google-protobuf (~> 4.28)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     unicode-display_width (2.6.0)
     webrick (1.9.0)
 
 PLATFORMS
+  aarch64-linux
+  aarch64-linux-android
+  aarch64-linux-gnu
+  aarch64-linux-musl
   aarch64-mingw-ucrt
+  arm-linux-androideabi
+  arm-linux-gnu
+  arm-linux-gnueabihf
+  arm-linux-musl
+  arm-linux-musleabihf
   arm64-darwin
+  riscv64-linux-android
+  riscv64-linux-gnu
+  riscv64-linux-musl
   ruby
   x86-cygwin
+  x86-linux
+  x86-linux-android
+  x86-linux-gnu
+  x86-linux-musl
   x86-mingw-ucrt
   x86_64-cygwin
   x86_64-darwin
-  x86_64-linux
+  x86_64-linux-android
+  x86_64-linux-gnu
+  x86_64-linux-musl
 
 DEPENDENCIES
+  base64
+  csv
   jekyll (~> 4.3.3)
   jekyll-environment-variables
   webrick
 
 BUNDLED WITH
-   2.5.18
+   2.5.22

--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,3 @@
-baseurl: ''
 permalink: /:title/
 title: 'Water Lilies Community Energy'
 
@@ -55,7 +54,7 @@ exclude:
   - Procfile
   - Rakefile
 
-# for github pages setup uncomment the code and set to your domain
-# domain: yourdomain.com      # if you want to force HTTPS, specify the domain without the http at the start, e.g. example.com
-url: https://cepro.github.io/  # the base hostname and protocol for your site, e.g. http://example.com
-baseurl: 'www.waterlilies.energy-jekyll'       # place folder name if the site is served in a subfolder   
+# for local run
+url: http://0.0.0.0:4000
+baseurl: ''
+host: 0.0.0.0

--- a/_config_github_pages.yml
+++ b/_config_github_pages.yml
@@ -1,0 +1,4 @@
+# for github pages setup uncomment the code and set to your domain
+# domain: yourdomain.com      # if you want to force HTTPS, specify the domain without the http at the start, e.g. example.com
+url: https://cepro.github.io/  # the base hostname and protocol for your site, e.g. http://example.com
+baseurl: 'www.waterlilies.energy-jekyll'       # place folder name if the site is served in a subfolder   

--- a/bin/build-docker
+++ b/bin/build-docker
@@ -1,0 +1,2 @@
+#!/bin/sh
+docker build -t wlce-jekyll .

--- a/bin/run-docker
+++ b/bin/run-docker
@@ -1,0 +1,2 @@
+#!/bin/sh
+docker run --rm -it -p 4000:4000 wlce-jekyll


### PR DESCRIPTION
- add the Gemfile.lock so bundle will install the exact same dependencies for each checkout
- add a Dockerfile for local runs
- fix warnings about using gem deps for core libs that are moving - csv and base64 regenerated Gemfile.lock which added these deps and a set of linux platforms
- default _config.yml to a local run on 0.0.0.0 add _config_github_pages.yml for github pages specific config overrides
- add util scripts for docker build and run